### PR TITLE
Adding the ability to nest animations within slots on a parent animation

### DIFF
--- a/gddragonbones.h
+++ b/gddragonbones.h
@@ -84,6 +84,7 @@ private:
     bool                        b_inherit_child_material;
 
 protected:
+	GDArmatureDisplay *_build_armature_from_resource(const String &_armature_name, Ref<GDDragonBones::GDDragonBonesResource> _p_data, const String &_texture_path);
     void _notification(int _what);
 	static void _bind_methods();
 
@@ -165,6 +166,8 @@ public:
 	int get_total_items_in_slot(const String &_slot_name);
 	void cycle_next_item_in_slot(const String &_slot_name);
 	void cycle_previous_item_in_slot(const String &_slot_name);
+
+	void nest_armature_in_slot(const String &_armature_name, const String &_slot_name, Ref<GDDragonBonesResource> resource);
 
 	// Playback
 	bool is_playing() const;

--- a/gddragonbones.h
+++ b/gddragonbones.h
@@ -66,7 +66,10 @@ public:
 private:
     GDFactory*                  p_factory;
 	Ref<TEXTURE_CLASS> m_texture_atlas;
-    Ref<GDDragonBonesResource>  m_res;
+	Ref<GDDragonBonesResource> m_res;
+	Dictionary					child_animations;
+
+	std::map<String, GDArmatureDisplay*>					_active_child_animations;
     String                      str_curr_anim;
     GDArmatureDisplay*          p_armature;
     AnimMode                    m_anim_mode;
@@ -144,6 +147,8 @@ public:
 	bool is_fliped_x() const;
 	void flip_y(bool _b_flip);
 	bool is_fliped_y() const;
+	void set_child_animations(Dictionary child_animations);
+	Dictionary get_child_animations();
 
 	// animation state
 	String get_current_animation() const;
@@ -167,7 +172,7 @@ public:
 	void cycle_next_item_in_slot(const String &_slot_name);
 	void cycle_previous_item_in_slot(const String &_slot_name);
 
-	void nest_armature_in_slot(const String &_armature_name, const String &_slot_name, Ref<GDDragonBonesResource> resource);
+	void display_child_animation_on_slot(const String &_child_animation_name, const String &_slot_name);
 
 	// Playback
 	bool is_playing() const;


### PR DESCRIPTION
Wiki for this feature: https://github.com/mauville-technologies/godot_dragonbones/wiki/Feature:-Nested-Dragonbones-Projects

Very likely going to go into a `3.2.52` release (2 releases from now) -- as this has a ripple effect and I want to design it right;

this PR proves the concept though

New function signatures:

```
sprite.nest_armature_in_slot(project_name, slot_name, _ske_resource)

```

____

In this GIF, the hat is a separate `Hat` dragonbones project and nested within a `hat` slot on the `Player` project
Define your child animations in editor:
![image](https://user-images.githubusercontent.com/1694066/89726379-0784b880-d9e8-11ea-9508-ae4557a179da.png)

```
onready var sprite = $Sprite

# Called when the node enters the scene tree for the first time.
func _ready():
    
    sprite.display_child_animation_on_slot("OtherHat", "hat") 
```

![ezgif-7-aa7f72888820](https://user-images.githubusercontent.com/1694066/89726394-208d6980-d9e8-11ea-9f24-d1aa1b003f59.gif)

