### PR TITLE
Adding Android templates to the build

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ ___
 
 2. [See the official docs](http://docs.godotengine.org/en/latest/development/compiling/)
 for compilation instructions for every supported platform.
+
+#### Platform specific flags
+- By default, javascript and android templates have `no-rtti` build flag enabled in their builds. Provided in the `/build` folder are a javascript and android rtti patch to be applied over the main Godot repository. This will remove these build flags and enable export templates for those platforms.
+
+```
+cd $GODOT_SOURCE_DIR
+
+git apply build/android-no-rtti-patch.patch
+git apply build/js-no-rtti-patch.patch
+```
 ___
 ##
 [![Sample](./sample.gif)]()

--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ ___
 for compilation instructions for every supported platform.
 
 #### Platform specific flags
-- By default, javascript and android templates have `no-rtti` build flag enabled in their builds. Provided in the `/build` folder are a javascript and android rtti patch to be applied over the main Godot repository. This will remove these build flags and enable export templates for those platforms.
+- By default, javascript and android templates have `no-rtti` build flag enabled in their builds. Unfortunately, the DragonBones CPP API makes use of `typeid` quite abit and requires rtti. I believe it mostly affects build size a bit
+
+Provided in the `/build` folder are a javascript and android rtti patch to be applied over the main Godot repository. This will remove these build flags and enable export templates for those platforms.
 
 ```
 cd $GODOT_SOURCE_DIR

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -6,16 +6,16 @@ SHELL ["/bin/bash", "-c"]
 RUN set +H
 
 # needed for mac builds
-ENV GODOT_VERSION="3.2"
+ENV GODOT_VERSION="tags/3.2.3-stable"
 ENV GODOT_DRAGONBONES_VERSION="3.2.52"
-ENV GODOT_DRAGONBONES_BRANCH="child_armatures"
+ENV GODOT_DRAGONBONES_BRANCH="master"
 ENV OSXCROSS_ROOT="/osxcross"
 ENV GODOT_SOURCE_LOCATION="/godot"
 ENV EMSCRIPTEN_LOCATION="/emscripten"
 ENV ANDROID_HOME="/AndroidSDK"
 ENV ANDROID_NDK="/AndroidNDK"
 ENV ANDROID_NDK_ROOT="${ANDROID_NDK}/ndk"
-ENV ANDROID_NDK_HOME="${ANDROID_NDK}/ndk"
+ENV ANDROID_NDK_HOME="${ANDROID_NDK_ROOT}"
 ENV DEBIAN_FRONTEND="noninteractive"
 ENV UNATTENDED=true
 
@@ -76,7 +76,7 @@ RUN mkdir -p $ANDROID_HOME/cmdline-tools && \
 
 RUN mkdir -p ${ANDROID_NDK_ROOT} && \
     wget -O AndroidNDK.zip https://dl.google.com/android/repository/android-ndk-r21d-linux-x86_64.zip && \
-    unzip AndroidNDK.zip -d ${ANDROID_NDK} && mv ${ANDROID_NDK}/* ${ANDROID_NDK}/ndk
+    unzip AndroidNDK.zip -d ${ANDROID_NDK} && mv ${ANDROID_NDK}/* ${ANDROID_NDK_ROOT}
 
 # iphone deps ?
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -70,13 +70,13 @@ RUN python -m pip install scons && \
 RUN apt -y install default-jdk
 
 RUN mkdir -p $ANDROID_HOME/cmdline-tools && \
-    wget -q -O AndroidSDK.zip https://dl.google.com/android/repository/commandlinetools-linux-6609375_latest.zip && \
-    unzip -q AndroidSDK.zip -d ${ANDROID_HOME}/cmdline-tools && \
+    wget -O AndroidSDK.zip https://dl.google.com/android/repository/commandlinetools-linux-6609375_latest.zip && \
+    unzip AndroidSDK.zip -d ${ANDROID_HOME}/cmdline-tools && \
     yes | ${ANDROID_HOME}/cmdline-tools/tools/bin/sdkmanager --licenses
 
-RUN mkdir -p ${ANDROID_NDK_ROOT} && \
+RUN mkdir -p ${ANDROID_NDK} && \
     wget -q -O AndroidNDK.zip https://dl.google.com/android/repository/android-ndk-r21d-linux-x86_64.zip && \
-    unzip -q AndroidNDK.zip -d ${ANDROID_NDK} &&  cd ${ANDROID_NDK} && mv * ndk
+    unzip -q AndroidNDK.zip -d ${ANDROID_NDK} && mv ${ANDROID_NDK}/* ${ANDROID_NDK_ROOT}
 
 # iphone deps ?
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -67,7 +67,7 @@ RUN python -m pip install scons && \
     sed -i '1s/\#!\/usr\/local\/bin\/python/\#!\/usr\/bin\/python3/' /usr/local/bin/scons
 
 # android deps ?
-RUN apt install default-jdk
+RUN apt -y install default-jdk
 
 RUN mkdir -p $ANDROID_HOME/cmdline-tools && \
     wget -O AndroidSDK.zip https://dl.google.com/android/repository/commandlinetools-linux-6609375_latest.zip && \

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -70,13 +70,13 @@ RUN python -m pip install scons && \
 RUN apt -y install default-jdk
 
 RUN mkdir -p $ANDROID_HOME/cmdline-tools && \
-    wget -O AndroidSDK.zip https://dl.google.com/android/repository/commandlinetools-linux-6609375_latest.zip && \
-    unzip AndroidSDK.zip -d ${ANDROID_HOME}/cmdline-tools && \
+    wget -q -O AndroidSDK.zip https://dl.google.com/android/repository/commandlinetools-linux-6609375_latest.zip && \
+    unzip -q AndroidSDK.zip -d ${ANDROID_HOME}/cmdline-tools && \
     yes | ${ANDROID_HOME}/cmdline-tools/tools/bin/sdkmanager --licenses
 
 RUN mkdir -p ${ANDROID_NDK_ROOT} && \
-    wget -O AndroidNDK.zip https://dl.google.com/android/repository/android-ndk-r21d-linux-x86_64.zip && \
-    unzip AndroidNDK.zip -d ${ANDROID_NDK} && mv ${ANDROID_NDK}/* ${ANDROID_NDK_ROOT}
+    wget -q -O AndroidNDK.zip https://dl.google.com/android/repository/android-ndk-r21d-linux-x86_64.zip && \
+    unzip -q AndroidNDK.zip -d ${ANDROID_NDK} &&  cd ${ANDROID_NDK} && mv * ndk
 
 # iphone deps ?
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -12,6 +12,10 @@ ENV GODOT_DRAGONBONES_BRANCH="child_armatures"
 ENV OSXCROSS_ROOT="/osxcross"
 ENV GODOT_SOURCE_LOCATION="/godot"
 ENV EMSCRIPTEN_LOCATION="/emscripten"
+ENV ANDROID_HOME="/AndroidSDK"
+ENV ANDROID_NDK="/AndroidNDK"
+ENV ANDROID_NDK_ROOT="${ANDROID_NDK}/ndk"
+ENV ANDROID_NDK_HOME="${ANDROID_NDK}/ndk"
 ENV DEBIAN_FRONTEND="noninteractive"
 ENV UNATTENDED=true
 
@@ -63,6 +67,16 @@ RUN python -m pip install scons && \
     sed -i '1s/\#!\/usr\/local\/bin\/python/\#!\/usr\/bin\/python3/' /usr/local/bin/scons
 
 # android deps ?
+RUN apt install default-jdk
+
+RUN mkdir -p $ANDROID_HOME/cmdline-tools && \
+    wget -O AndroidSDK.zip https://dl.google.com/android/repository/commandlinetools-linux-6609375_latest.zip && \
+    unzip AndroidSDK.zip -d ${ANDROID_HOME}/cmdline-tools && \
+    yes | ${ANDROID_HOME}/cmdline-tools/tools/bin/sdkmanager --licenses
+
+RUN mkdir -p ${ANDROID_NDK_ROOT} && \
+    wget -O AndroidNDK.zip https://dl.google.com/android/repository/android-ndk-r21d-linux-x86_64.zip && \
+    unzip AndroidNDK.zip -d ${ANDROID_NDK} && mv ${ANDROID_NDK}/* ${ANDROID_NDK}/ndk
 
 # iphone deps ?
 
@@ -90,6 +104,9 @@ WORKDIR ${GODOT_SOURCE_LOCATION}
 
 COPY ./js-no-rtti-patch.patch .
 RUN git apply js-no-rtti-patch.patch
+
+COPY ./android-no-rtti-patch.patch .
+RUN git apply android-no-rtti-patch.patch
 
 # COPY BUILD SCRIPT
 COPY ./container-build-script.sh .

--- a/build/android-no-rtti-patch.patch
+++ b/build/android-no-rtti-patch.patch
@@ -10,3 +10,4 @@ index ed0643e3b3..1b61a7ac54 100644
 +        env.Append(CXXFLAGS=["-fno-exceptions"])
          # Don't use dynamic_cast, necessary with no-rtti.
          env.Append(CPPDEFINES=["NO_SAFE_CAST"])
+

--- a/build/android-no-rtti-patch.patch
+++ b/build/android-no-rtti-patch.patch
@@ -1,0 +1,12 @@
+diff --git a/platform/android/detect.py b/platform/android/detect.py
+index ed0643e3b3..1b61a7ac54 100644
+--- a/platform/android/detect.py
++++ b/platform/android/detect.py
+@@ -216,7 +216,7 @@ def configure(env):
+     if env["tools"]:
+         env.Append(CXXFLAGS=["-frtti"])
+     else:
+-        env.Append(CXXFLAGS=["-fno-rtti", "-fno-exceptions"])
++        env.Append(CXXFLAGS=["-fno-exceptions"])
+         # Don't use dynamic_cast, necessary with no-rtti.
+         env.Append(CPPDEFINES=["NO_SAFE_CAST"])

--- a/build/container-build-script.sh
+++ b/build/container-build-script.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-install clang 
+# install clang 
 cd $OSXCROSS_ROOT/build/llvm-9.0.0.src/build_stage2 && make install
 cd $OSXCROSS_ROOT
 ./build.sh

--- a/build/container-build-script.sh
+++ b/build/container-build-script.sh
@@ -1,36 +1,36 @@
 #!/bin/bash
 # install clang 
-cd $OSXCROSS_ROOT/build/llvm-9.0.0.src/build_stage2 && make install
-cd $OSXCROSS_ROOT
-./build.sh
+# cd $OSXCROSS_ROOT/build/llvm-9.0.0.src/build_stage2 && make install
+# cd $OSXCROSS_ROOT
+# ./build.sh
 
 cd $GODOT_SOURCE_LOCATION
 
 ###########################
 ##      ENGINE FILES     ##
 ###########################
-/usr/local/bin/scons -j8 platform=x11 target=release_debug bits=32 use_lto=yes optimize=size
-/usr/local/bin/scons -j8 platform=x11 target=release_debug bits=64 use_lto=yes optimize=size
+# /usr/local/bin/scons -j8 platform=x11 target=release_debug bits=32 use_lto=yes optimize=size
+# /usr/local/bin/scons -j8 platform=x11 target=release_debug bits=64 use_lto=yes optimize=size
 
-# windows
-/usr/local/bin/scons -j8 platform=windows target=release_debug bits=32 use_lto=yes use_mingw=yes optimize=size
-/usr/local/bin/scons -j8 platform=windows target=release_debug bits=64 use_lto=yes use_mingw=yes optimize=size
+# # windows
+# /usr/local/bin/scons -j8 platform=windows target=release_debug bits=32 use_lto=yes use_mingw=yes optimize=size
+# /usr/local/bin/scons -j8 platform=windows target=release_debug bits=64 use_lto=yes use_mingw=yes optimize=size
 
-#osx
-/usr/local/bin/scons -j8 platform=osx target=release_debug osxcross_sdk=darwin19 optimize=size
+# #osx
+# /usr/local/bin/scons -j8 platform=osx target=release_debug osxcross_sdk=darwin19 optimize=size
 
-# Copy all builds to builds directory
-mkdir -p /build/engine
+# # Copy all builds to builds directory
+# mkdir -p /build/engine
 
-# Package .app
-cp -r misc/dist/osx_tools.app ./Godot-dragonbones-$GODOT_DRAGONBONES_VERSION.app
-mkdir -p Godot-dragonbones-$GODOT_DRAGONBONES_VERSION.app/Contents/MacOS
-mv bin/*osx.opt.tools* Godot-dragonbones-$GODOT_DRAGONBONES_VERSION.app/Contents/MacOS/Godot
-chmod +x Godot-dragonbones-$GODOT_DRAGONBONES_VERSION.app/Contents/MacOS/Godot
-rm -f /build/engine/Godot-dragonbones.osx.64.zip
-zip -r -y /build/engine/Godot-dragonbones.osx.64.zip Godot-dragonbones-$GODOT_DRAGONBONES_VERSION.app
+# # Package .app
+# cp -r misc/dist/osx_tools.app ./Godot-dragonbones-$GODOT_DRAGONBONES_VERSION.app
+# mkdir -p Godot-dragonbones-$GODOT_DRAGONBONES_VERSION.app/Contents/MacOS
+# mv bin/*osx.opt.tools* Godot-dragonbones-$GODOT_DRAGONBONES_VERSION.app/Contents/MacOS/Godot
+# chmod +x Godot-dragonbones-$GODOT_DRAGONBONES_VERSION.app/Contents/MacOS/Godot
+# rm -f /build/engine/Godot-dragonbones.osx.64.zip
+# zip -r -y /build/engine/Godot-dragonbones.osx.64.zip Godot-dragonbones-$GODOT_DRAGONBONES_VERSION.app
 
-cp -av bin/. /build/engine
+# cp -av bin/. /build/engine
 
 ###########################
 ##      TEMPLATE FILES     ##
@@ -41,70 +41,92 @@ rm -rf bin/
 # load emscripten
 source $EMSCRIPTEN_LOCATION/emsdk_env.sh
 
-# headless
-/usr/local/bin/scons -j8 debug_symbols=no use_static_cpp=yes use_lto=yes platform=server tools=no target=release optimize=size
+# # headless
+# /usr/local/bin/scons -j8 debug_symbols=no use_static_cpp=yes use_lto=yes platform=server tools=no target=release optimize=size
 
-#x11
-/usr/local/bin/scons -j8 platform=x11 target=release bits=32 use_lto=yes tools=no debug_symbols=no optimize=size
-/usr/local/bin/scons -j8 platform=x11 target=release_debug bits=32 use_lto=yes tools=no debug_symbols=no optimize=size
-/usr/local/bin/scons -j8 platform=x11 target=release bits=64 use_lto=yes tools=no debug_symbols=no optimize=size
-/usr/local/bin/scons -j8 platform=x11 target=release_debug bits=64 use_lto=yes tools=no debug_symbols=no optimize=size
+# #x11
+# /usr/local/bin/scons -j8 platform=x11 target=release bits=32 use_lto=yes tools=no debug_symbols=no optimize=size
+# /usr/local/bin/scons -j8 platform=x11 target=release_debug bits=32 use_lto=yes tools=no debug_symbols=no optimize=size
+# /usr/local/bin/scons -j8 platform=x11 target=release bits=64 use_lto=yes tools=no debug_symbols=no optimize=size
+# /usr/local/bin/scons -j8 platform=x11 target=release_debug bits=64 use_lto=yes tools=no debug_symbols=no optimize=size
 
-# windows
-/usr/local/bin/scons -j8 platform=windows target=release_debug bits=32 use_lto=yes tools=no debug_symbols=no use_mingw=yes optimize=size
-/usr/local/bin/scons -j8 platform=windows target=release bits=32 use_lto=yes tools=no debug_symbols=no use_mingw=yes optimize=size
-/usr/local/bin/scons -j8 platform=windows target=release_debug bits=64 use_lto=yes tools=no debug_symbols=no use_mingw=yes optimize=size
-/usr/local/bin/scons -j8 platform=windows target=release bits=64 use_lto=yes tools=no debug_symbols=no use_mingw=yes optimize=size
+# # windows
+# /usr/local/bin/scons -j8 platform=windows target=release_debug bits=32 use_lto=yes tools=no debug_symbols=no use_mingw=yes optimize=size
+# /usr/local/bin/scons -j8 platform=windows target=release bits=32 use_lto=yes tools=no debug_symbols=no use_mingw=yes optimize=size
+# /usr/local/bin/scons -j8 platform=windows target=release_debug bits=64 use_lto=yes tools=no debug_symbols=no use_mingw=yes optimize=size
+# /usr/local/bin/scons -j8 platform=windows target=release bits=64 use_lto=yes tools=no debug_symbols=no use_mingw=yes optimize=size
 
-# osx
-/usr/local/bin/scons -j8 platform=osx target=release_debug osxcross_sdk=darwin19 debug_symbols=no tools=no optimize=size
-/usr/local/bin/scons -j8 platform=osx target=release osxcross_sdk=darwin19 debug_symbols=no tools=no optimize=size
+# # osx
+# /usr/local/bin/scons -j8 platform=osx target=release_debug osxcross_sdk=darwin19 debug_symbols=no tools=no optimize=size
+# /usr/local/bin/scons -j8 platform=osx target=release osxcross_sdk=darwin19 debug_symbols=no tools=no optimize=size
 
-# HTML5
-/usr/local/bin/scons -j8 platform=javascript tools=no target=release javascript_eval=no debug_symbols=no
-/usr/local/bin/scons -j8 platform=javascript tools=no target=release_debug javascript_eval=no debug_symbols=no
+# # HTML5
+# /usr/local/bin/scons -j8 platform=javascript tools=no target=release javascript_eval=no debug_symbols=no
+# /usr/local/bin/scons -j8 platform=javascript tools=no target=release_debug javascript_eval=no debug_symbols=no
+
+# Android
+
+
+# Build all 4 architectures
+# release
+
+/usr/local/bin/scons -j8 platform=android tools=no target=release debug_symbols=no android_arch=armv7
+/usr/local/bin/scons -j8 platform=android tools=no target=release debug_symbols=no android_arch=arm64v8
+/usr/local/bin/scons -j8 platform=android tools=no target=release debug_symbols=no android_arch=x86
+/usr/local/bin/scons -j8 platform=android tools=no target=release debug_symbols=no android_arch=x86_64
+
+#debug
+/usr/local/bin/scons -j8 platform=android  tools=no target=release_debug debug_symbols=no android_arch=armv7
+/usr/local/bin/scons -j8 platform=android  tools=no target=release_debug debug_symbols=no android_arch=arm64v8
+/usr/local/bin/scons -j8 platform=android  tools=no target=release_debug debug_symbols=no android_arch=x86
+/usr/local/bin/scons -j8 platform=android  tools=no target=release_debug debug_symbols=no android_arch=x86_64
+
+cd platform/android/java
+./gradlew generateGodotTemplates
+
+cd $GODOT_SOURCE_LOCATION
 
 # Copy all builds to builds directory
 mkdir -p /build/templates
 
 # move headless first
-mv bin/*server.* /build/templates
+# mv bin/*server.* /build/templates
 
-# rename to expected format and move to expected folder
-mv bin/*x11.opt.debug.32* bin/linux_x11_32_debug
-mv bin/*x11.opt.debug.64* bin/linux_x11_64_debug
-mv bin/*x11.opt.32* bin/linux_x11_32_release
-mv bin/*x11.opt.64* bin/linux_x11_64_release
+# # rename to expected format and move to expected folder
+# mv bin/*x11.opt.debug.32* bin/linux_x11_32_debug
+# mv bin/*x11.opt.debug.64* bin/linux_x11_64_debug
+# mv bin/*x11.opt.32* bin/linux_x11_32_release
+# mv bin/*x11.opt.64* bin/linux_x11_64_release
 
-mv bin/*windows.opt.debug.32* bin/windows_32_debug.exe
-mv bin/*windows.opt.debug.64* bin/windows_64_debug.exe
-mv bin/*windows.opt.32* bin/windows_32_release.exe
-mv bin/*windows.opt.64* bin/windows_64_release.exe
+# mv bin/*windows.opt.debug.32* bin/windows_32_debug.exe
+# mv bin/*windows.opt.debug.64* bin/windows_64_debug.exe
+# mv bin/*windows.opt.32* bin/windows_32_release.exe
+# mv bin/*windows.opt.64* bin/windows_64_release.exe
 
-mv bin/godot.javascript.opt.zip bin/webassembly_release.zip
-mv bin/godot.javascript.opt.debug.zip bin/webassembly_debug.zip
+# mv bin/godot.javascript.opt.zip bin/webassembly_release.zip
+# mv bin/godot.javascript.opt.debug.zip bin/webassembly_debug.zip
 
 # Package .app
 
 # copy the directory over
-cp -r misc/dist/osx_template.app bin/osx_template.app
+# cp -r misc/dist/osx_template.app bin/osx_template.app
 
-mkdir -p bin/osx_template.app/Contents/MacOS
-mv bin/*osx.opt.debug.64* bin/osx_template.app/Contents/MacOS/godot_osx_debug.64
-mv bin/*osx.opt.64* bin/osx_template.app/Contents/MacOS/godot_osx_release.64
-chmod +x bin/osx_template.app/Contents/MacOS/godot_osx_debug.64
-chmod +x bin/osx_template.app/Contents/MacOS/godot_osx_release.64
-cd bin
-zip -r osx.zip osx_template.app
-cd ..
+# mkdir -p bin/osx_template.app/Contents/MacOS
+# mv bin/*osx.opt.debug.64* bin/osx_template.app/Contents/MacOS/godot_osx_debug.64
+# mv bin/*osx.opt.64* bin/osx_template.app/Contents/MacOS/godot_osx_release.64
+# chmod +x bin/osx_template.app/Contents/MacOS/godot_osx_debug.64
+# chmod +x bin/osx_template.app/Contents/MacOS/godot_osx_release.64
+# cd bin
+# zip -r osx.zip osx_template.app
+# cd ..
 
-rm -rf bin/osx_template.app
+# rm -rf bin/osx_template.app
 
 # Add version.txt
 echo "3.2.52.stable" > bin/version.txt
 
-rm bin/*.js bin/*.wasm
-rm -r bin/.javascript_zip
+# rm bin/*.js bin/*.wasm
+# rm -r bin/.javascript_zip
 
 # zip file
 mv ./bin ./templates

--- a/build/container-build-script.sh
+++ b/build/container-build-script.sh
@@ -95,7 +95,7 @@ mkdir -p /build/templates
 # move headless first
 mv bin/*server.* /build/templates
 
-# # rename to expected format and move to expected folder
+# rename to expected format and move to expected folder
 mv bin/*x11.opt.debug.32* bin/linux_x11_32_debug
 mv bin/*x11.opt.debug.64* bin/linux_x11_64_debug
 mv bin/*x11.opt.32* bin/linux_x11_32_release

--- a/build/container-build-script.sh
+++ b/build/container-build-script.sh
@@ -1,36 +1,36 @@
 #!/bin/bash
-# install clang 
-# cd $OSXCROSS_ROOT/build/llvm-9.0.0.src/build_stage2 && make install
-# cd $OSXCROSS_ROOT
-# ./build.sh
+install clang 
+cd $OSXCROSS_ROOT/build/llvm-9.0.0.src/build_stage2 && make install
+cd $OSXCROSS_ROOT
+./build.sh
 
 cd $GODOT_SOURCE_LOCATION
 
 ###########################
 ##      ENGINE FILES     ##
 ###########################
-# /usr/local/bin/scons -j8 platform=x11 target=release_debug bits=32 use_lto=yes optimize=size
-# /usr/local/bin/scons -j8 platform=x11 target=release_debug bits=64 use_lto=yes optimize=size
+/usr/local/bin/scons -j8 platform=x11 target=release_debug bits=32 use_lto=yes optimize=size
+/usr/local/bin/scons -j8 platform=x11 target=release_debug bits=64 use_lto=yes optimize=size
 
-# # windows
-# /usr/local/bin/scons -j8 platform=windows target=release_debug bits=32 use_lto=yes use_mingw=yes optimize=size
-# /usr/local/bin/scons -j8 platform=windows target=release_debug bits=64 use_lto=yes use_mingw=yes optimize=size
+# windows
+/usr/local/bin/scons -j8 platform=windows target=release_debug bits=32 use_lto=yes use_mingw=yes optimize=size
+/usr/local/bin/scons -j8 platform=windows target=release_debug bits=64 use_lto=yes use_mingw=yes optimize=size
 
-# #osx
-# /usr/local/bin/scons -j8 platform=osx target=release_debug osxcross_sdk=darwin19 optimize=size
+#osx
+/usr/local/bin/scons -j8 platform=osx target=release_debug osxcross_sdk=darwin19 optimize=size
 
-# # Copy all builds to builds directory
-# mkdir -p /build/engine
+# Copy all builds to builds directory
+mkdir -p /build/engine
 
-# # Package .app
-# cp -r misc/dist/osx_tools.app ./Godot-dragonbones-$GODOT_DRAGONBONES_VERSION.app
-# mkdir -p Godot-dragonbones-$GODOT_DRAGONBONES_VERSION.app/Contents/MacOS
-# mv bin/*osx.opt.tools* Godot-dragonbones-$GODOT_DRAGONBONES_VERSION.app/Contents/MacOS/Godot
-# chmod +x Godot-dragonbones-$GODOT_DRAGONBONES_VERSION.app/Contents/MacOS/Godot
-# rm -f /build/engine/Godot-dragonbones.osx.64.zip
-# zip -r -y /build/engine/Godot-dragonbones.osx.64.zip Godot-dragonbones-$GODOT_DRAGONBONES_VERSION.app
+# Package .app
+cp -r misc/dist/osx_tools.app ./Godot-dragonbones-$GODOT_DRAGONBONES_VERSION.app
+mkdir -p Godot-dragonbones-$GODOT_DRAGONBONES_VERSION.app/Contents/MacOS
+mv bin/*osx.opt.tools* Godot-dragonbones-$GODOT_DRAGONBONES_VERSION.app/Contents/MacOS/Godot
+chmod +x Godot-dragonbones-$GODOT_DRAGONBONES_VERSION.app/Contents/MacOS/Godot
+rm -f /build/engine/Godot-dragonbones.osx.64.zip
+zip -r -y /build/engine/Godot-dragonbones.osx.64.zip Godot-dragonbones-$GODOT_DRAGONBONES_VERSION.app
 
-# cp -av bin/. /build/engine
+cp -av bin/. /build/engine
 
 ###########################
 ##      TEMPLATE FILES     ##
@@ -41,32 +41,30 @@ rm -rf bin/
 # load emscripten
 source $EMSCRIPTEN_LOCATION/emsdk_env.sh
 
-# # headless
-# /usr/local/bin/scons -j8 debug_symbols=no use_static_cpp=yes use_lto=yes platform=server tools=no target=release optimize=size
+# headless
+/usr/local/bin/scons -j8 debug_symbols=no use_static_cpp=yes use_lto=yes platform=server tools=no target=release optimize=size
 
-# #x11
-# /usr/local/bin/scons -j8 platform=x11 target=release bits=32 use_lto=yes tools=no debug_symbols=no optimize=size
-# /usr/local/bin/scons -j8 platform=x11 target=release_debug bits=32 use_lto=yes tools=no debug_symbols=no optimize=size
-# /usr/local/bin/scons -j8 platform=x11 target=release bits=64 use_lto=yes tools=no debug_symbols=no optimize=size
-# /usr/local/bin/scons -j8 platform=x11 target=release_debug bits=64 use_lto=yes tools=no debug_symbols=no optimize=size
+#x11
+/usr/local/bin/scons -j8 platform=x11 target=release bits=32 use_lto=yes tools=no debug_symbols=no optimize=size
+/usr/local/bin/scons -j8 platform=x11 target=release_debug bits=32 use_lto=yes tools=no debug_symbols=no optimize=size
+/usr/local/bin/scons -j8 platform=x11 target=release bits=64 use_lto=yes tools=no debug_symbols=no optimize=size
+/usr/local/bin/scons -j8 platform=x11 target=release_debug bits=64 use_lto=yes tools=no debug_symbols=no optimize=size
 
-# # windows
-# /usr/local/bin/scons -j8 platform=windows target=release_debug bits=32 use_lto=yes tools=no debug_symbols=no use_mingw=yes optimize=size
-# /usr/local/bin/scons -j8 platform=windows target=release bits=32 use_lto=yes tools=no debug_symbols=no use_mingw=yes optimize=size
-# /usr/local/bin/scons -j8 platform=windows target=release_debug bits=64 use_lto=yes tools=no debug_symbols=no use_mingw=yes optimize=size
-# /usr/local/bin/scons -j8 platform=windows target=release bits=64 use_lto=yes tools=no debug_symbols=no use_mingw=yes optimize=size
+# windows
+/usr/local/bin/scons -j8 platform=windows target=release_debug bits=32 use_lto=yes tools=no debug_symbols=no use_mingw=yes optimize=size
+/usr/local/bin/scons -j8 platform=windows target=release bits=32 use_lto=yes tools=no debug_symbols=no use_mingw=yes optimize=size
+/usr/local/bin/scons -j8 platform=windows target=release_debug bits=64 use_lto=yes tools=no debug_symbols=no use_mingw=yes optimize=size
+/usr/local/bin/scons -j8 platform=windows target=release bits=64 use_lto=yes tools=no debug_symbols=no use_mingw=yes optimize=size
 
-# # osx
-# /usr/local/bin/scons -j8 platform=osx target=release_debug osxcross_sdk=darwin19 debug_symbols=no tools=no optimize=size
-# /usr/local/bin/scons -j8 platform=osx target=release osxcross_sdk=darwin19 debug_symbols=no tools=no optimize=size
+# osx
+/usr/local/bin/scons -j8 platform=osx target=release_debug osxcross_sdk=darwin19 debug_symbols=no tools=no optimize=size
+/usr/local/bin/scons -j8 platform=osx target=release osxcross_sdk=darwin19 debug_symbols=no tools=no optimize=size
 
-# # HTML5
-# /usr/local/bin/scons -j8 platform=javascript tools=no target=release javascript_eval=no debug_symbols=no
-# /usr/local/bin/scons -j8 platform=javascript tools=no target=release_debug javascript_eval=no debug_symbols=no
+# HTML5
+/usr/local/bin/scons -j8 platform=javascript tools=no target=release javascript_eval=no debug_symbols=no
+/usr/local/bin/scons -j8 platform=javascript tools=no target=release_debug javascript_eval=no debug_symbols=no
 
 # Android
-
-
 # Build all 4 architectures
 # release
 
@@ -86,47 +84,52 @@ cd platform/android/java
 
 cd $GODOT_SOURCE_LOCATION
 
+# move the AAR files to engine folder
+mv bin/*.aar /build/engine
+# remove android_source
+rm bin/android_source.zip
+
 # Copy all builds to builds directory
 mkdir -p /build/templates
 
 # move headless first
-# mv bin/*server.* /build/templates
+mv bin/*server.* /build/templates
 
 # # rename to expected format and move to expected folder
-# mv bin/*x11.opt.debug.32* bin/linux_x11_32_debug
-# mv bin/*x11.opt.debug.64* bin/linux_x11_64_debug
-# mv bin/*x11.opt.32* bin/linux_x11_32_release
-# mv bin/*x11.opt.64* bin/linux_x11_64_release
+mv bin/*x11.opt.debug.32* bin/linux_x11_32_debug
+mv bin/*x11.opt.debug.64* bin/linux_x11_64_debug
+mv bin/*x11.opt.32* bin/linux_x11_32_release
+mv bin/*x11.opt.64* bin/linux_x11_64_release
 
-# mv bin/*windows.opt.debug.32* bin/windows_32_debug.exe
-# mv bin/*windows.opt.debug.64* bin/windows_64_debug.exe
-# mv bin/*windows.opt.32* bin/windows_32_release.exe
-# mv bin/*windows.opt.64* bin/windows_64_release.exe
+mv bin/*windows.opt.debug.32* bin/windows_32_debug.exe
+mv bin/*windows.opt.debug.64* bin/windows_64_debug.exe
+mv bin/*windows.opt.32* bin/windows_32_release.exe
+mv bin/*windows.opt.64* bin/windows_64_release.exe
 
-# mv bin/godot.javascript.opt.zip bin/webassembly_release.zip
-# mv bin/godot.javascript.opt.debug.zip bin/webassembly_debug.zip
+mv bin/godot.javascript.opt.zip bin/webassembly_release.zip
+mv bin/godot.javascript.opt.debug.zip bin/webassembly_debug.zip
 
 # Package .app
 
 # copy the directory over
-# cp -r misc/dist/osx_template.app bin/osx_template.app
+cp -r misc/dist/osx_template.app bin/osx_template.app
 
-# mkdir -p bin/osx_template.app/Contents/MacOS
-# mv bin/*osx.opt.debug.64* bin/osx_template.app/Contents/MacOS/godot_osx_debug.64
-# mv bin/*osx.opt.64* bin/osx_template.app/Contents/MacOS/godot_osx_release.64
-# chmod +x bin/osx_template.app/Contents/MacOS/godot_osx_debug.64
-# chmod +x bin/osx_template.app/Contents/MacOS/godot_osx_release.64
-# cd bin
-# zip -r osx.zip osx_template.app
-# cd ..
+mkdir -p bin/osx_template.app/Contents/MacOS
+mv bin/*osx.opt.debug.64* bin/osx_template.app/Contents/MacOS/godot_osx_debug.64
+mv bin/*osx.opt.64* bin/osx_template.app/Contents/MacOS/godot_osx_release.64
+chmod +x bin/osx_template.app/Contents/MacOS/godot_osx_debug.64
+chmod +x bin/osx_template.app/Contents/MacOS/godot_osx_release.64
+cd bin
+zip -r osx.zip osx_template.app
+cd ..
 
-# rm -rf bin/osx_template.app
+rm -rf bin/osx_template.app
 
 # Add version.txt
 echo "3.2.52.stable" > bin/version.txt
 
-# rm bin/*.js bin/*.wasm
-# rm -r bin/.javascript_zip
+rm bin/*.js bin/*.wasm
+rm -r bin/.javascript_zip
 
 # zip file
 mv ./bin ./templates

--- a/gddragonbones.cpp
+++ b/gddragonbones.cpp
@@ -218,7 +218,7 @@ void GDDragonBones::set_resource(Ref<GDDragonBonesResource> _p_data)
     m_res = _p_data;
     if (m_res.is_null())
     {
-        m_texture_atlas = Ref<Texture>();
+        m_texture_atlas = Ref<TEXTURE_CLASS>();
         ERR_PRINT("Null resources");
         _change_notify();
 		return;

--- a/gddragonbones.h
+++ b/gddragonbones.h
@@ -90,7 +90,7 @@ public:
     void dispatch_snd_event(const String& _str_type, const EventObject* _p_value);
 
     // setters/getters
-    void set_resource(Ref<GDDragonBonesResource> _p_data);
+	void set_resource(Ref<GDDragonBonesResource> _p_data);
     Ref<GDDragonBonesResource> get_resource();
 
     void set_inherit_material(bool _b_enable);

--- a/register_types.cpp
+++ b/register_types.cpp
@@ -100,7 +100,7 @@ public:
 
 };
 
-static ResourceFormatLoaderGDDragonBones *resource_loader_GDDragonBones = NULL;
+static Ref<ResourceFormatLoaderGDDragonBones> resource_loader_GDDragonBones = NULL;
 
 void register_godot_dragonbones_types()
 {
@@ -109,14 +109,15 @@ void register_godot_dragonbones_types()
 	REG_VIRTUAL_CLASS_BIND_GODO<GDSlot>();
 	REG_VIRTUAL_CLASS_BIND_GODO<GDBone2D>();
     REG_CLASS_BIND_GODO<GDDragonBones::GDDragonBonesResource>();
-	resource_loader_GDDragonBones = memnew( ResourceFormatLoaderGDDragonBones );
+
+	resource_loader_GDDragonBones.instance();
 	ResourceLoader::add_resource_format_loader(resource_loader_GDDragonBones);
 }
 
 void unregister_godot_dragonbones_types()
 {
-	if (resource_loader_GDDragonBones)
-		memdelete(resource_loader_GDDragonBones);
+	ResourceLoader::remove_resource_format_loader(resource_loader_GDDragonBones);
+	resource_loader_GDDragonBones->unreference();
 }
 
 

--- a/src/GDArmatureDisplay.cpp
+++ b/src/GDArmatureDisplay.cpp
@@ -12,6 +12,8 @@ GDArmatureDisplay::GDArmatureDisplay()
 
 GDArmatureDisplay::~GDArmatureDisplay()
 {
+	_bones.clear();
+	_slots.clear();
 	dispose(true);
 }
 


### PR DESCRIPTION
Since i found that GLES3 doesnt work in HTML5 on Android, I figured providing Android export templates may be helpful.

(I have a fairly strong distaste towards Apple's ecosystem and don't own an iPhone -- someone else will have to figure out how to automate iPhone builds :) )

Current status:

- I have successfully created the APKs. There are some leftover files and I have to test the apks.

___

BONUS: I fixed the crash on shutdown error inherited from the original codebase. This should silence the "Quit unexpectedly" warning seen on Mac OS