### PR TITLE
fix enums bindings

### DIFF
--- a/src/GDArmatureDisplay.cpp
+++ b/src/GDArmatureDisplay.cpp
@@ -47,15 +47,15 @@ void GDArmatureDisplay::_bind_methods() {
 
 
 	// Enum
-	BIND_CONSTANT(ANIMATION_PROCESS_FIXED);
-	BIND_CONSTANT(ANIMATION_PROCESS_IDLE);
+	BIND_ENUM_CONSTANT(ANIMATION_PROCESS_FIXED);
+	BIND_ENUM_CONSTANT(ANIMATION_PROCESS_IDLE);
 
-	BIND_CONSTANT(FadeOut_None);
-	BIND_CONSTANT(FadeOut_SameLayer);
-	BIND_CONSTANT(FadeOut_SameGroup);
-	BIND_CONSTANT(FadeOut_SameLayerAndGroup);
-	BIND_CONSTANT(FadeOut_All);
-	BIND_CONSTANT(FadeOut_Single);
+	BIND_ENUM_CONSTANT(FadeOut_None);
+	BIND_ENUM_CONSTANT(FadeOut_SameLayer);
+	BIND_ENUM_CONSTANT(FadeOut_SameGroup);
+	BIND_ENUM_CONSTANT(FadeOut_SameLayerAndGroup);
+	BIND_ENUM_CONSTANT(FadeOut_All);
+	BIND_ENUM_CONSTANT(FadeOut_Single);
 }
 
 bool GDArmatureDisplay::is_frozen() {


### PR DESCRIPTION
I wanted to bind rust language together with `godot_dragonbones` via gdnative, but faced with the fact that enums which are returned from methods in Godot have no bindings, or rather they are made constants, so generated `api.json` had no enums, I corrected this. Please see if this breaks anything, I never wrote modules for godot but it works fine for me.